### PR TITLE
Annotate Asserter.IsNotNull with [NotNull] attribute.

### DIFF
--- a/src/Microsoft.UnitTestFramework.Extensions/Asserter.cs
+++ b/src/Microsoft.UnitTestFramework.Extensions/Asserter.cs
@@ -6,6 +6,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+#if NETSTANDARD2_1_OR_GREATER
+    using System.Diagnostics.CodeAnalysis;
+#endif
     using System.Linq;
     using static FailedTestMessage;
 
@@ -495,14 +498,14 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <param name="value">The object to verify is not null.</param>
         /// <exception cref="AssertFailedException">
         /// <paramref name="value" /> is null.</exception>
-        public virtual void IsNotNull( object value ) => Assert.IsNotNull( value );
+        public virtual void IsNotNull( [NotNull] object value ) => Assert.IsNotNull( value );
 
         /// <summary>Verifies that the specified object is not null. The assertion fails if it is null. Displays a message if the assertion fails.</summary>
         /// <param name="value">The object to verify is not null.</param>
         /// <param name="message">A message to display if the assertion fails. This message can be seen in the unit test results.</param>
         /// <exception cref="AssertFailedException">
         /// <paramref name="value" /> is null.</exception>
-        public virtual void IsNotNull( object value, string message ) => Assert.IsNotNull( value, message );
+        public virtual void IsNotNull( [NotNull] object value, string message ) => Assert.IsNotNull( value, message );
 
         /// <summary>Verifies that the specified object is not null. The assertion fails if it is null. Displays a message if the assertion fails, and applies the specified formatting to it.</summary>
         /// <param name="value">The object to verify is not null.</param>
@@ -510,7 +513,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <param name="parameters">An array of parameters to use when formatting <paramref name="message" />.</param>
         /// <exception cref="AssertFailedException">
         /// <paramref name="value" /> is null.</exception>
-        public virtual void IsNotNull( object value, string message, params object[] parameters ) => Assert.IsNotNull( value, message, parameters );
+        public virtual void IsNotNull( [NotNull] object value, string message, params object[] parameters ) => Assert.IsNotNull( value, message, parameters );
 
         /// <summary>Verifies that the specified object is null. The assertion fails if it is not null.</summary>
         /// <param name="value">The object to verify is null.</param>

--- a/src/Microsoft.UnitTestFramework.Extensions/Microsoft.UnitTestFramework.Extensions.csproj
+++ b/src/Microsoft.UnitTestFramework.Extensions/Microsoft.UnitTestFramework.Extensions.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
   <VersionPrefix>2.0.0</VersionPrefix>
   <AssemblyVersion>2.0.0.0</AssemblyVersion>
-  <TargetFrameworks>netstandard1.0;net45;uap10.0</TargetFrameworks>
+  <TargetFrameworks>netstandard1.0;netstandard2.1;net45;uap10.0</TargetFrameworks>
   <AssemblyTitle>Microsoft Visual Studio Unit Test Framework Extensions</AssemblyTitle>
   <Description>This package contains extensions to the Microsoft Visual Studio Team Test unit testing framework. Features include alternatives to ExpectedExceptionAttribute and a fully extensible assertion application programming interface.</Description>
   <RootNamespace>Microsoft.VisualStudio.TestTools.UnitTesting</RootNamespace>

--- a/src/Microsoft.UnitTestFramework.Extensions/NotNullAttribute.cs
+++ b/src/Microsoft.UnitTestFramework.Extensions/NotNullAttribute.cs
@@ -1,0 +1,13 @@
+﻿#if NETSTANDARD2_1_OR_GREATER
+namespace Microsoft.VisualStudio.TestTools.UnitTesting
+{
+    using System;
+    /// <summary>
+    /// PlaceHolder for System.Diagnostics.CodeAnalysis.NotNullAttribute for platforms where that attribute is not available.
+    /// </summary>
+    [AttributeUsage( AttributeTargets.Parameter )]
+    internal class NotNullAttribute : Attribute
+    {
+    }
+}
+#endif


### PR DESCRIPTION
This helps nullability analysis in test projects.

```CSharp
//result may be null
var result = Some.Code();
Assert.IsNotNull(result);
// This will not have a nullability warning
Assert.IsTrue(result.Success);
```